### PR TITLE
Console output

### DIFF
--- a/src/controller/interpreter.rs
+++ b/src/controller/interpreter.rs
@@ -24,6 +24,7 @@ use crate::runtime;
 
 async fn entry_future(input: String, output: Arc<Mutex<String>>, render_tx: Arc<RenderTx>) {
     let result = runtime::entry(input, render_tx);
+
     let string = match result {
         Ok(val) => format!("{}", val),
         Err(err) => format!("{}", err),

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use druid::Data;
 use druid::Lens;
@@ -27,7 +28,7 @@ use super::render::RenderTx;
 pub struct AppState {
     pub command_count: u32,
     pub input: Arc<String>,
-    pub output: Arc<String>,
+    pub output: Arc<Mutex<String>>,
     pub pixels: PixBuf,
     pub pos: Point,
     pub show_turtle: bool,
@@ -50,7 +51,7 @@ impl AppState {
         Self {
             command_count: 0,
             input: "".to_string().into(),
-            output: "".to_string().into(),
+            output: Arc::new(Mutex::new("".to_string())),
             pixels: Default::default(),
             pos: Point::ZERO,
             show_turtle: false,

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -1,0 +1,109 @@
+// Copyright 2021 Andy King
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use druid::widget::prelude::*;
+use druid::widget::Label;
+use druid::widget::LineBreaking;
+use druid::Color;
+use druid::TextAlignment;
+use druid::TimerToken;
+use druid::Widget;
+
+use super::constants::*;
+use crate::model::app::AppState;
+
+fn build_console_label() -> Label<AppState> {
+    Label::new("")
+        .with_font(druid::FontDescriptor::new(druid::FontFamily::MONOSPACE).with_size(FONT_SIZE))
+        .with_text_color(Color::WHITE)
+        .with_text_alignment(TextAlignment::Start)
+        .with_line_break_mode(LineBreaking::WordWrap)
+}
+
+pub struct Console {
+    label: Label<AppState>,
+    output: String,
+    timer_id: TimerToken,
+}
+
+impl Console {
+    pub fn new() -> Self {
+        Self {
+            label: build_console_label(),
+            output: "".to_string(),
+            timer_id: TimerToken::INVALID,
+        }
+    }
+
+    fn update_output(&mut self, data: &mut AppState) -> bool {
+        let guard = data.output.lock().unwrap();
+        let output = guard.to_string();
+
+        if output != self.output {
+            self.output = output;
+            self.label.set_text(self.output.clone());
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Widget<AppState> for Console {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut AppState, env: &Env) {
+        match event {
+            Event::Timer(timer_id) => {
+                if self.timer_id == *timer_id {
+                    if self.update_output(data) {
+                        ctx.request_update();
+                    }
+                    self.timer_id = ctx.request_timer(Duration::from_millis(100));
+                }
+            }
+
+            Event::WindowConnected => {
+                self.timer_id = ctx.request_timer(Duration::from_millis(100));
+            }
+
+            _ => {}
+        }
+
+        self.label.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &AppState, env: &Env) {
+        self.label.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &AppState, data: &AppState, env: &Env) {
+        self.label.update(ctx, old_data, data, env);
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &AppState,
+        env: &Env,
+    ) -> Size {
+        self.label.layout(ctx, bc, data, env);
+        bc.max()
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &AppState, env: &Env) {
+        self.label.paint(ctx, data, env);
+    }
+}

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -49,16 +49,15 @@ impl Console {
     }
 
     fn update_output(&mut self, data: &mut AppState) -> bool {
-        let guard = data.output.lock().unwrap();
-        let output = guard.to_string();
+        let output = { data.output.lock().unwrap().clone() };
 
-        if output != self.output {
-            self.output = output;
-            self.label.set_text(self.output.clone());
-            true
-        } else {
-            false
+        if output == self.output {
+            return false;
         }
+
+        self.output = output;
+        self.label.set_text(self.output.clone());
+        true
     }
 }
 

--- a/src/view/constants.rs
+++ b/src/view/constants.rs
@@ -12,23 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+pub const FONT_SIZE: f64 = 14.0;
 
-pub type ValueList = Vec<Value>;
+pub const CONSOLE_HEIGHT: f64 = FONT_SIZE * 6.0 + 8.0;
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum Value {
-    Void,
-    List(ValueList),
-    Number(f64),
-}
+pub const INPUT_WIDTH: f64 = 300.0;
 
-impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Value::Void => write!(f, "void"),
-            Value::List(_) => write!(f, "[]"),
-            Value::Number(num) => write!(f, "{}", num),
-        }
-    }
-}
+pub const STATUS_BAR_HEIGHT: f64 = FONT_SIZE + 8.0;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod canvas;
-pub mod menu;
+mod canvas;
+mod console;
+mod constants;
+mod menu;
 pub mod window;

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -18,6 +18,8 @@ use druid::widget::Container;
 use druid::widget::Controller;
 use druid::widget::CrossAxisAlignment;
 use druid::widget::Flex;
+use druid::widget::Label;
+use druid::widget::MainAxisAlignment;
 use druid::widget::TextBox;
 use druid::widget::Widget;
 use druid::Color;
@@ -28,15 +30,12 @@ use druid::WidgetExt;
 use druid::WindowDesc;
 
 use super::canvas::Canvas;
+use super::console::Console;
+use super::constants::*;
 use super::menu;
-
 use crate::common::constants::*;
 use crate::model::app::AppState;
 use crate::model::render::RenderRx;
-
-const FONT_SIZE: f64 = 14.0;
-const INPUT_WIDTH: f64 = 300.0;
-const STATUS_BAR_HEIGHT: f64 = FONT_SIZE + 8.0;
 
 pub fn window(render_rx: RenderRx) -> WindowDesc<AppState> {
     let ui = build_ui(render_rx);
@@ -56,10 +55,12 @@ fn build_ui(render_rx: RenderRx) -> impl Widget<AppState> {
         .controller(WindowController {})
 }
 
-fn build_center_pane(render_rx: RenderRx) -> impl druid::Widget<AppState> {
+fn build_center_pane(render_rx: RenderRx) -> impl Widget<AppState> {
     Flex::column()
-        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .cross_axis_alignment(CrossAxisAlignment::End)
         .with_child(build_canvas(render_rx))
+        .with_spacer(1.0)
+        .with_child(build_console())
         .with_spacer(1.0)
         .with_child(build_status_bar())
         .with_default_spacer()
@@ -101,8 +102,17 @@ fn build_input() -> impl Widget<AppState> {
     )
 }
 
-fn build_status_label() -> impl druid::Widget<AppState> {
-    druid::widget::Label::new(|data: &AppState, _env: &_| {
+fn build_console() -> impl Widget<AppState> {
+    Flex::row()
+        .main_axis_alignment(MainAxisAlignment::Start)
+        .with_child(Console::new())
+        .background(Color::BLACK)
+        .fix_width(DIMS.width)
+        .fix_height(CONSOLE_HEIGHT)
+}
+
+fn build_status_label() -> impl Widget<AppState> {
+    Label::new(|data: &AppState, _: &_| {
         format!(
             "commands: {:6}   speed: {:2}",
             data.command_count, data.speed
@@ -112,9 +122,9 @@ fn build_status_label() -> impl druid::Widget<AppState> {
     .with_text_color(Color::WHITE)
 }
 
-fn build_status_bar() -> impl druid::Widget<AppState> {
+fn build_status_bar() -> impl Widget<AppState> {
     Flex::row()
-        .main_axis_alignment(druid::widget::MainAxisAlignment::End)
+        .main_axis_alignment(MainAxisAlignment::End)
         .with_child(build_status_label())
         .fix_width(DIMS.width)
         .fix_height(STATUS_BAR_HEIGHT)
@@ -122,7 +132,10 @@ fn build_status_bar() -> impl druid::Widget<AppState> {
 }
 
 fn window_size() -> Size {
-    Size::new(DIMS.width + INPUT_WIDTH, DIMS.height + STATUS_BAR_HEIGHT)
+    Size::new(
+        DIMS.width + INPUT_WIDTH,
+        DIMS.height + CONSOLE_HEIGHT + STATUS_BAR_HEIGHT + 2.0,
+    )
 }
 
 struct WindowController {}

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -60,9 +60,9 @@ fn build_center_pane(render_rx: RenderRx) -> impl Widget<AppState> {
         .cross_axis_alignment(CrossAxisAlignment::End)
         .with_child(build_canvas(render_rx))
         .with_spacer(1.0)
-        .with_child(build_console())
-        .with_spacer(1.0)
         .with_child(build_status_bar())
+        .with_spacer(1.0)
+        .with_child(build_console())
         .with_default_spacer()
 }
 


### PR DESCRIPTION
Add console output, so the user can see the result (the value of the last expression evaluated) or the error (which is super important). I tried doing this as just a dynamic label, but it refused to update without being poked, usually with an extra key press. So I moved it into a custom widget and added a timer.