### PR TITLE
Control speed from interpreter side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1685,7 @@ dependencies = [
  "druid",
  "futures",
  "rand",
+ "threadpool",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,8 @@ git = "https://github.com/linebender/druid"
 version = "0.3.15"
 features = ["executor", "thread-pool"]
 
+[dependencies.threadpool]
+version = "1.8.1"
+
 [dependencies.rand]
 version = "0.8.3"

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -18,3 +18,7 @@ use druid::Size;
 pub const DIMS: Size = Size::new(800.0, 600.0);
 
 pub const ORIGIN: Point = Point::new(DIMS.width / 2.0, DIMS.height / 2.0);
+
+pub const MIN_SPEED: u32 = 32;
+
+pub const MAX_SPEED: u32 = 32;

--- a/src/controller/delegate.rs
+++ b/src/controller/delegate.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::common::commands;
+use crate::model::app::AppState;
 use druid::DelegateCtx;
 use druid::Env;
 use druid::Handled;
 use druid::Target;
-
-use crate::common::commands;
-use crate::model::app::AppState;
 
 pub struct Delegate;
 

--- a/src/controller/examples.rs
+++ b/src/controller/examples.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
-use druid::DelegateCtx;
-
 use crate::common::commands;
 use crate::model::app::AppState;
+use druid::DelegateCtx;
+use std::sync::Arc;
 
 pub fn show(_ctx: &mut DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
     let example = match *cmd.get_unchecked(commands::EXAMPLES) {

--- a/src/controller/interpreter.rs
+++ b/src/controller/interpreter.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::sync::Mutex;
-
-use druid::DelegateCtx;
-
 use crate::common::commands;
 use crate::common::constants::MAX_SPEED;
 use crate::common::constants::MIN_SPEED;
 use crate::model::app::AppState;
 use crate::runtime;
+use druid::DelegateCtx;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 fn set_output(output: &Arc<Mutex<String>>, string: &str) {
     let mut output_guard = output.lock().unwrap();

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
-use std::sync::Arc;
-
+use crate::model::pixbuf::PixBuf;
 use druid::Color;
 use druid::Point;
-
-use crate::model::pixbuf::PixBuf;
+use std::collections::VecDeque;
+use std::sync::Arc;
 
 pub fn line(pixels: &mut PixBuf, p: &Point, q: &Point, color: &Color) {
     let bytes = Arc::make_mut(&mut pixels.bytes);

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex;
 use druid::Data;
 use druid::Lens;
 use druid::Point;
-use futures::executor::ThreadPool;
+use threadpool::ThreadPool;
 
 use super::pixbuf::PixBuf;
 use super::render::RenderTx;
@@ -42,11 +42,7 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(render_tx: RenderTx, window_id: druid::WindowId) -> Self {
-        let thread_pool = ThreadPool::builder()
-            .pool_size(1)
-            .name_prefix("render-tx")
-            .create()
-            .expect("Failed to create thread pool");
+        let thread_pool = ThreadPool::new(1);
 
         Self {
             command_count: 0,

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -31,8 +33,9 @@ pub struct AppState {
     pub output: Arc<Mutex<String>>,
     pub pixels: PixBuf,
     pub pos: Point,
+    pub running: Arc<AtomicBool>,
     pub show_turtle: bool,
-    pub speed: u8,
+    pub speed: Arc<AtomicU32>,
     pub thread_pool: Arc<ThreadPool>,
     pub render_tx: Arc<RenderTx>,
 
@@ -42,17 +45,16 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(render_tx: RenderTx, window_id: druid::WindowId) -> Self {
-        let thread_pool = ThreadPool::new(1);
-
         Self {
             command_count: 0,
             input: "".to_string().into(),
             output: Arc::new(Mutex::new("".to_string())),
             pixels: Default::default(),
             pos: Point::ZERO,
+            running: Arc::new(AtomicBool::new(false)),
             show_turtle: false,
-            speed: 4,
-            thread_pool: Arc::new(thread_pool),
+            speed: Arc::new(AtomicU32::new(4)),
+            thread_pool: Arc::new(ThreadPool::new(1)),
             render_tx: Arc::new(render_tx),
             window_id,
         }

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::pixbuf::PixBuf;
+use super::render::RenderTx;
+use druid::Data;
+use druid::Lens;
+use druid::Point;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::sync::Mutex;
-
-use druid::Data;
-use druid::Lens;
-use druid::Point;
 use threadpool::ThreadPool;
-
-use super::pixbuf::PixBuf;
-use super::render::RenderTx;
 
 /// Application state.
 #[derive(Clone, Data, Debug, Lens)]

--- a/src/model/pixbuf.rs
+++ b/src/model/pixbuf.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
+use crate::common::bits;
+use crate::common::constants::*;
 use druid::Color;
 use druid::Data;
 use druid::Point;
-
-use crate::common::bits;
-use crate::common::constants::*;
+use std::sync::Arc;
 
 #[derive(Clone, Data, Debug)]
 pub struct PixBuf {

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-
-use futures::channel::mpsc::TrySendError;
-
 use crate::model::render::RenderCommand;
+use futures::channel::mpsc::TrySendError;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum RuntimeError {

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -557,17 +557,6 @@ impl Interpreter {
         Ok(())
     }
 
-    fn tx(&mut self, cmd: RenderCommand) -> RuntimeResult {
-        self.render_tx_count += 1;
-        if self.render_tx_count % self.speed.load(Ordering::Relaxed) == 0 {
-            thread::sleep(Duration::from_millis(30));
-        }
-
-        self.render_tx.unbounded_send(cmd)?;
-
-        Ok(())
-    }
-
     fn move_to_inner(&mut self, angle: f64, p: Point) -> RuntimeResult {
         let move_to = MoveTo::new(
             angle,
@@ -578,6 +567,17 @@ impl Interpreter {
         );
 
         self.tx(RenderCommand::MoveTo(move_to))
+    }
+
+    fn tx(&mut self, cmd: RenderCommand) -> RuntimeResult {
+        self.render_tx_count += 1;
+        if self.render_tx_count % self.speed.load(Ordering::Relaxed) == 0 {
+            thread::sleep(Duration::from_millis(30));
+        }
+
+        self.render_tx.unbounded_send(cmd)?;
+
+        Ok(())
     }
 
     fn vlist_expect(list: &[Value], n: usize) -> RuntimeResult {

--- a/src/runtime/interpreter.rs
+++ b/src/runtime/interpreter.rs
@@ -12,22 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::error::*;
+use super::interpreter_types::*;
+use super::lexer_types::*;
+use super::parser_types::*;
+use crate::model::render::*;
+use druid::Color;
+use druid::Point;
+use rand::Rng;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-
-use druid::Color;
-use druid::Point;
-use rand::Rng;
-
-use super::error::*;
-use super::interpreter_types::*;
-use super::lexer_types::*;
-use super::parser_types::*;
-use crate::model::render::*;
 
 type VarMap = HashMap<String, Value>;
 

--- a/src/runtime/lexer.rs
+++ b/src/runtime/lexer.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::iter::Peekable;
-use std::str::Chars;
-
 use super::error::*;
 use super::lexer_types::*;
+use std::iter::Peekable;
+use std::str::Chars;
 
 #[derive(Clone, Debug)]
 struct LexerState {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -54,7 +54,7 @@ mod tests {
     fn it_goes() {
         let input = "let i = (2 ^ 3) i".to_string();
         let (render_tx, render_rx) = mpsc::unbounded::<RenderCommand>();
-        let res = entry(input, Arc::new(render_tx));
+        let res = entry(input, Arc::new(render_tx), Arc::new(AtomicU32::new(4)));
         if let Err(err) = res {
             eprintln!("{}", err);
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicU32;
-use std::sync::Arc;
-
 use crate::model::render::RenderTx;
 use error::*;
 use interpreter::Interpreter;
 use interpreter_types::*;
 use lexer::Lexer;
 use parser::Parser;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
 
 pub mod error;
 mod interpreter;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use crate::model::render::RenderTx;
@@ -29,13 +30,16 @@ mod lexer_types;
 mod parser;
 mod parser_types;
 
-pub fn entry(input: String, render_tx: Arc<RenderTx>) -> RuntimeResult<Value> {
-    println!("Runtime starting...");
+pub fn entry(
+    input: String,
+    render_tx: Arc<RenderTx>,
+    speed: Arc<AtomicU32>,
+) -> RuntimeResult<Value> {
     let lexer_out = Lexer::new().go(&input)?;
     println!("lexer out {:?}", lexer_out);
     let parser_out = Parser::new().go(&lexer_out)?;
     println!("parser out {:?}", parser_out);
-    let intrp_out = Interpreter::new(render_tx).go(&parser_out)?;
+    let intrp_out = Interpreter::new(render_tx, speed).go(&parser_out)?;
     println!("interpreter out {:?}", intrp_out);
     Ok(intrp_out)
 }

--- a/src/runtime/parser.rs
+++ b/src/runtime/parser.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use super::error::*;
 use super::lexer_types::*;
 use super::parser_types::*;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 struct ListIter<'a> {

--- a/src/runtime/parser_types.rs
+++ b/src/runtime/parser_types.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use super::lexer_types::*;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BinExprNode {

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
-
+use crate::common::constants::*;
+use crate::graphics;
+use crate::model::app::AppState;
+use crate::model::render::*;
 use druid::kurbo::Circle;
 use druid::piet::ImageFormat;
 use druid::piet::InterpolationMode;
@@ -23,11 +25,7 @@ use druid::Point;
 use druid::Rect;
 use druid::TimerToken;
 use druid::Widget;
-
-use crate::common::constants::*;
-use crate::graphics;
-use crate::model::app::AppState;
-use crate::model::render::*;
+use std::time::Duration;
 
 pub struct Canvas {
     render_rx: RenderRx,

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -72,7 +72,7 @@ impl Canvas {
 
     pub fn render(&mut self, data: &mut AppState) -> bool {
         let mut dirty = false;
-        for _ in 0..data.speed {
+        for _ in 0..MAX_SPEED {
             if let Ok(Some(cmd)) = self.render_rx.try_next() {
                 self.render_one(data, cmd);
                 dirty = true;

--- a/src/view/console.rs
+++ b/src/view/console.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
-
 use druid::widget::prelude::*;
 use druid::widget::Label;
 use druid::widget::LineBreaking;
@@ -21,6 +19,7 @@ use druid::Color;
 use druid::TextAlignment;
 use druid::TimerToken;
 use druid::Widget;
+use std::time::Duration;
 
 use super::constants::*;
 use crate::model::app::AppState;

--- a/src/view/menu.rs
+++ b/src/view/menu.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::common::commands;
+use crate::model::app::AppState;
 use druid::menu::Menu;
 use druid::menu::MenuItem;
 use druid::widget::prelude::*;
 use druid::LocalizedString;
 use druid::SysMods;
 use druid::WindowId;
-
-use crate::common::commands;
-use crate::model::app::AppState;
 
 pub fn menu_bar(_: Option<WindowId>, _: &AppState, _: &Env) -> Menu<AppState> {
     #[cfg(target_os = "macos")]

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
+use super::canvas::Canvas;
+use super::console::Console;
+use super::constants::*;
+use super::menu;
+use crate::common::constants::*;
+use crate::model::app::AppState;
+use crate::model::render::RenderRx;
 use druid::theme;
 use druid::widget::prelude::*;
 use druid::widget::Container;
@@ -30,14 +35,7 @@ use druid::FontFamily;
 use druid::Size;
 use druid::WidgetExt;
 use druid::WindowDesc;
-
-use super::canvas::Canvas;
-use super::console::Console;
-use super::constants::*;
-use super::menu;
-use crate::common::constants::*;
-use crate::model::app::AppState;
-use crate::model::render::RenderRx;
+use std::sync::atomic::Ordering;
 
 pub fn window(render_rx: RenderRx) -> WindowDesc<AppState> {
     let ui = build_ui(render_rx);

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::Ordering;
+
 use druid::theme;
 use druid::widget::prelude::*;
 use druid::widget::Container;
@@ -115,7 +117,8 @@ fn build_status_label() -> impl Widget<AppState> {
     Label::new(|data: &AppState, _: &_| {
         format!(
             "commands: {:6}   speed: {:2}",
-            data.command_count, data.speed
+            data.command_count,
+            data.speed.load(Ordering::Relaxed)
         )
     })
     .with_font(druid::FontDescriptor::new(druid::FontFamily::MONOSPACE).with_size(FONT_SIZE))


### PR DESCRIPTION
Let's control the speed from the interpreter (tx), instead of from the canvas (rx). This way what you see is what's actually being evaluated, time-wise. It also lets us make it interactive in the future, if we want to. To do this, we switch from tasks to threads, so that we can sleep and block. We only want one thread at a time running the interpreter, so let's block any attempt to run if the interpreter is already running.
